### PR TITLE
FEATURE: ajout des metrics de comptage et duree

### DIFF
--- a/src/api/metrics.js
+++ b/src/api/metrics.js
@@ -1,15 +1,8 @@
 require("../modules/env")
+const { register, http_request_total, http_request_duration_seconds }= require("../modules/metricsCollector")
 const express = require('express');
 const api = express.Router();
-const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
-const client = require("prom-client")
-const register = new client.Registry();
-client.collectDefaultMetrics(
-  { 
-    register: register,
-    prefix: `judilibre_`,
-    }
-  );
+
 
 api.get("/metrics", async (req, res, next) => {
   res.setHeader("Content-type", register.contentType);

--- a/src/modules/metricsCollector.js
+++ b/src/modules/metricsCollector.js
@@ -1,0 +1,24 @@
+const prometheusClient = require("prom-client")
+const register = new prometheusClient.Registry();
+
+const http_request_total = new prometheusClient.Counter({
+  name: "http_request_total",
+  help: "The total number of HTTP requests received",
+  labelNames: ["method", "route", "status_code"],
+});
+
+const http_request_duration_seconds = new prometheusClient.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+});
+
+
+
+register.registerMetric(http_request_total);
+register.registerMetric(http_request_duration_seconds);
+
+
+
+module.exports = { register, http_request_total, http_request_duration_seconds };

--- a/src/modules/server.js
+++ b/src/modules/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 const express = require('express');
 const cors = require('cors');
 const morgan = require('morgan');
+const { register, http_request_total, http_request_duration_seconds } = require('./metricsCollector')
 
 class Server {
   constructor() {
@@ -11,6 +12,30 @@ class Server {
     this.app.use(cors());
     this.app.use(express.json({ limit: '50mb' }));
     this.app.use(express.urlencoded({ extended: true }));
+    this.app.use((req, res, next) => {
+      const req_url = new URL(req.url, `http://${req.headers.host}`);
+      const original_res_send_function = res.send;
+      const res_send_interceptor = function (body) {
+        http_request_total.inc(
+          {
+            method: req.method,
+            route: req_url.pathname,
+            status_code: res.statusCode,
+          }
+        );
+        original_res_send_function.call(this, body);
+      };
+      res.send = res_send_interceptor;
+      next();
+    });
+    this.app.use((req, res, next) => {
+      const end = http_request_duration_seconds.startTimer({ method: req.method });
+      res.on("finish", () => {
+        const req_url = new URL(req.url, `http://${req.headers.host}`);
+        end({ route: req_url.pathname,  status_code: res.statusCode });
+      });
+      next();
+    });
     this.app.use((req, res, next) => {
       res.setHeader('X-Powered-By', false);
       res.setHeader('X-Content-Type-Options', 'nosniff');


### PR DESCRIPTION
Les modifications promises. J'ai viré toutes les autres métriques (celles par défaut) et j'ai construit deux fonctions en middleware qui récupèrent respectivement la durée et le nombre de requêtes. 

Pour tester, il faut lancer l'application et aller sur [http://localhost:8080/metrics](http://localhost:8080/metrics). On peut simplement raffraichir la page puis aller sur les autres endpoints pour voir comment ça modifie ces chiffres.

J'aurais peut-être pu faire une seule fonction pour gérer les deux mais bon.